### PR TITLE
Fix pyproject package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "cutsimulator"
 version = "0.1.0"
 description = "Kubernetes workload simulator"
-readme = "README.md"
+readme = "Readme.md"
 requires-python = ">=3.8"
 authors = [{name = "CUT"}]
 license = {text = "MIT"}
@@ -25,3 +25,7 @@ dependencies = [
 cluster-controller = "scripts.cluster_controller:main"
 simulation-controller = "scripts.simulation_controller:main"
 training-controller = "scripts.training_controller:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["cutsimulator*"]


### PR DESCRIPTION
## Summary
- fix README path in pyproject
- define package discovery for flat repo layout

## Testing
- `pip install --no-deps -e .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688095e0ea8483328d36aa1e3f7df86b